### PR TITLE
Refactor for heroku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=<Your postgres database uri>

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ requests = "*"
 tortoise-orm = "*"
 pydantic = "*"
 aerich = "*"
+python-dotenv = "*"
+asyncpg = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5215968f13c5b751cd310452ccd1b96c759fd7b0971530248f0e18c794a9cb00"
+            "sha256": "220968bae0982ce3e616c5e121b19f5072470a81068351a5552d31a201e74362"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -126,6 +126,38 @@
             "markers": "python_version >= '3.6'",
             "version": "==4.0.2"
         },
+        "asyncpg": {
+            "hashes": [
+                "sha256:0a61fb196ce4dae2f2fa26eb20a778db21bbee484d2e798cb3cc988de13bdd1b",
+                "sha256:18d49e2d93a7139a2fdbd113e320cc47075049997268a61bfbe0dde680c55471",
+                "sha256:191fe6341385b7fdea7dbdcf47fd6db3fd198827dcc1f2b228476d13c05a03c6",
+                "sha256:1a70783f6ffa34cc7dd2de20a873181414a34fd35a4a208a1f1a7f9f695e4ec4",
+                "sha256:2633331cbc8429030b4f20f712f8d0fbba57fa8555ee9b2f45f981b81328b256",
+                "sha256:2bc197fc4aca2fd24f60241057998124012469d2e414aed3f992579db0c88e3a",
+                "sha256:4327f691b1bdb222df27841938b3e04c14068166b3a97491bec2cb982f49f03e",
+                "sha256:43cde84e996a3afe75f325a68300093425c2f47d340c0fc8912765cf24a1c095",
+                "sha256:52fab7f1b2c29e187dd8781fce896249500cf055b63471ad66332e537e9b5f7e",
+                "sha256:56d88d7ef4341412cd9c68efba323a4519c916979ba91b95d4c08799d2ff0c09",
+                "sha256:5e4105f57ad1e8fbc8b1e535d8fcefa6ce6c71081228f08680c6dea24384ff0e",
+                "sha256:63f8e6a69733b285497c2855464a34de657f2cccd25aeaeeb5071872e9382540",
+                "sha256:649e2966d98cc48d0646d9a4e29abecd8b59d38d55c256d5c857f6b27b7407ac",
+                "sha256:6f8f5fc975246eda83da8031a14004b9197f510c41511018e7b1bedde6968e92",
+                "sha256:72a1e12ea0cf7c1e02794b697e3ca967b2360eaa2ce5d4bfdd8604ec2d6b774b",
+                "sha256:739bbd7f89a2b2f6bc44cb8bf967dab12c5bc714fcbe96e68d512be45ecdf962",
+                "sha256:863d36eba4a7caa853fd7d83fad5fd5306f050cc2fe6e54fbe10cdb30420e5e9",
+                "sha256:a738f1b2876f30d710d3dc1e7858160a0afe1603ba16bf5f391f5316eb0ed855",
+                "sha256:a84d30e6f850bac0876990bcd207362778e2208df0bee8be8da9f1558255e634",
+                "sha256:acb311722352152936e58a8ee3c5b8e791b24e84cd7d777c414ff05b3530ca68",
+                "sha256:beaecc52ad39614f6ca2e48c3ca15d56e24a2c15cbfdcb764a4320cc45f02fd5",
+                "sha256:bf5e3408a14a17d480f36ebaf0401a12ff6ae5457fdf45e4e2775c51cc9517d3",
+                "sha256:bf6dc9b55b9113f39eaa2057337ce3f9ef7de99a053b8a16360395ce588925cd",
+                "sha256:ddb4c3263a8d63dcde3d2c4ac1c25206bfeb31fa83bd70fd539e10f87739dee4",
+                "sha256:f55918ded7b85723a5eaeb34e86e7b9280d4474be67df853ab5a7fa0cc7c6bf2",
+                "sha256:fe471ccd915b739ca65e2e4dbd92a11b44a5b37f2e38f70827a1c147dafe0fa8"
+            ],
+            "index": "pypi",
+            "version": "==0.25.0"
+        },
         "attrs": {
             "hashes": [
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
@@ -176,7 +208,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "click": {
@@ -272,7 +304,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "iniconfig": {
@@ -497,6 +529,14 @@
             "index": "pypi",
             "version": "==7.1.2"
         },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f",
+                "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"
+            ],
+            "index": "pypi",
+            "version": "==0.20.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
@@ -517,7 +557,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "tomlkit": {

--- a/jokesborrower/db.py
+++ b/jokesborrower/db.py
@@ -1,5 +1,7 @@
 import os
-from tortoise import Tortoise,run_async
+
+from tortoise import Tortoise, run_async
+
 from . import models
 
 TORTOISE_ORM = {
@@ -12,10 +14,12 @@ TORTOISE_ORM = {
     },
 }
 
+
 async def init():
     await Tortoise.init(db_url="sqlite://db.sqlite3", modules={"models": [models]})
     # Generate the schema
     await Tortoise.generate_schemas()
+
 
 if __name__ == "__main__":
     run_async(init())

--- a/jokesborrower/db.py
+++ b/jokesborrower/db.py
@@ -1,11 +1,17 @@
 import os
+from os.path import join
 
+from dotenv import load_dotenv
 from tortoise import Tortoise, run_async
 
 from . import models
 
+path = os.getcwd()
+dotenv_path: str = join(path, ".env")
+load_dotenv(dotenv_path, override=True)
+database_url: str = os.environ.get("DATABASE_URL")
 TORTOISE_ORM = {
-    "connections": {"default": os.environ.get("DATABASE_URL")},
+    "connections": {"default": database_url},
     "apps": {
         "models": {
             "models": [models, "aerich.models"],
@@ -16,7 +22,7 @@ TORTOISE_ORM = {
 
 
 async def init():
-    await Tortoise.init(db_url="sqlite://db.sqlite3", modules={"models": [models]})
+    await Tortoise.init(db_url=database_url, modules={"models": [models]})
     # Generate the schema
     await Tortoise.generate_schemas()
 

--- a/jokesborrower/jokesborrower.py
+++ b/jokesborrower/jokesborrower.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import List
 
 import aiohttp
 
@@ -19,8 +18,8 @@ class JokesBorrower(object):
         Args:
             url (str): API base url
             rate_limit (int, optional): The rate limit if any for the api. Defaults to None.
-            jokes_category (List, optional): Categories of jokes you want. Defaults to ["Any"]
             jokes_count (int, optional): The number of jokes you want. Defaults to 100.
+            start_id (int, optional): Start id for the ID Range query parameter. Defaults to 0
         """
         self.jokes_category = ["Any"]
         self.url = (
@@ -45,8 +44,8 @@ class JokesBorrower(object):
             for i in range(self.jokes_count):
                 self.tasks.append(asyncio.ensure_future(self.get_joke(session, i)))
             self.jokes = await asyncio.gather(*self.tasks)
-        print(self.jokes)
-        print(len(self.jokes))
+        # print(self.jokes)
+        # print(len(self.jokes))
         return self.jokes
 
     async def store_jokes(self, jokes):

--- a/jokesborrower/jokesborrower.py
+++ b/jokesborrower/jokesborrower.py
@@ -11,8 +11,8 @@ class JokesBorrower(object):
         self,
         url: str,
         rate_limit: int = None,
-        jokes_category: List = ["Any"],
         jokes_count: int = 100,
+        start_id: int = 0,
     ):
         """Constructor
 
@@ -22,27 +22,31 @@ class JokesBorrower(object):
             jokes_category (List, optional): Categories of jokes you want. Defaults to ["Any"]
             jokes_count (int, optional): The number of jokes you want. Defaults to 100.
         """
-        self.jokes_category = jokes_category
+        self.jokes_category = ["Any"]
         self.url = (
-            url + f"{','.join(self.jokes_category)}?type=twopart"
+            url + f"{','.join(self.jokes_category)}"
         )  # Build the jokes url by first concatenating the base url with a
         # comma-seperated string of each joke category and the type query parameter
         self.rate_limit = rate_limit  # ToDo: implement a way to throttle api requests to not exceed the rate limit
         self.jokes_count = jokes_count
-
+        self.start_id = start_id
         self.tasks = []
         self.jokes = []
 
-    async def get_joke(self, session):
-        async with session.get(self.url) as resp:
+    async def get_joke(self, session, id):
+        async with session.get(self.url + f"?idRange={self.start_id+id}") as resp:
             joke = await resp.json()
-            return joke
+            if joke["type"] == "twopart":
+                # print(joke)
+                return joke
 
     async def get_jokes(self):
         async with aiohttp.ClientSession() as session:
             for i in range(self.jokes_count):
-                self.tasks.append(asyncio.ensure_future(self.get_joke(session)))
+                self.tasks.append(asyncio.ensure_future(self.get_joke(session, i)))
             self.jokes = await asyncio.gather(*self.tasks)
+        print(self.jokes)
+        print(len(self.jokes))
         return self.jokes
 
     async def store_jokes(self, jokes):
@@ -63,8 +67,10 @@ class JokesBorrower(object):
 
     async def borrow_jokes(self):
         jokes_list = await self.get_jokes()
+        jokes_list = [joke for joke in jokes_list if joke]  # remove none types
         # Cleanup the jokes list returning only fields needed -> ["category","setup","delivery(punchline)"]
         for joke in jokes_list:
             self.reshape_response(joke)
         # store the jokes to the database
         await self.store_jokes(jokes_list)
+        return len(jokes_list)

--- a/main.py
+++ b/main.py
@@ -31,7 +31,9 @@ async def main():
         url="https://v2.jokeapi.dev/joke/", jokes_count=100, start_id=start_id
     )
     jokes_num: int = await jk.borrow_jokes()
-    print(f"{jokes_num} jokes borrowed successfully in {(time.time() - start_time)} seconds")
+    print(
+        f"{jokes_num} jokes borrowed successfully in {(time.time() - start_time)} seconds"
+    )
     logging.info(
         f"{jokes_num} jokes borrowed successfully in {(time.time() - start_time)} seconds"
     )

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
+import argparse
 import asyncio
 import logging
-import time
 import os
+import time
 
 from jokesborrower import JokesBorrower, db
 
@@ -11,17 +12,29 @@ logging.basicConfig(
     format="%(name)s - %(asctime)s - %(levelname)s - %(message)s",
 )
 
+# Create the parser
+count_parser = argparse.ArgumentParser(description="Jokesborrower id count")
+
+# Add arguments to the parser
+count_parser.add_argument(
+    "Joke_index", metavar="joke index", type=int, help="The jokes index to start from"
+)
+# Execute the parse_args() method
+args = count_parser.parse_args()
+start_id: int = args.Joke_index
+
 
 async def main():
     start_time = time.time()
     await db.init()
     jk = JokesBorrower(
-        url="https://v2.jokeapi.dev/joke/",
-        jokes_count=100,
+        url="https://v2.jokeapi.dev/joke/", jokes_count=100, start_id=start_id
     )
-    await jk.borrow_jokes()
-    print(F"100 jokes borrowed successfully in {(time.time() - start_time)} seconds")
-    logging.info(F"100 jokes borrowed successfully in {(time.time() - start_time)} seconds")
+    jokes_num: int = await jk.borrow_jokes()
+    print(f"{jokes_num} jokes borrowed successfully in {(time.time() - start_time)} seconds")
+    logging.info(
+        f"{jokes_num} jokes borrowed successfully in {(time.time() - start_time)} seconds"
+    )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,16 @@
 -i https://pypi.org/simple
+aerich==0.6.3
 aiohttp==3.8.1
 aiosignal==1.2.0
 aiosqlite==0.17.0
 async-timeout==4.0.2
+asyncpg==0.25.0
 attrs==21.4.0
 black==22.3.0
 certifi==2022.6.15
 charset-normalizer==2.0.12
 click==8.1.3
+dictdiffer==0.9.0
 flake8==4.0.1
 frozenlist==1.3.0
 idna==3.3
@@ -28,9 +31,11 @@ pyflakes==2.4.0
 pyparsing==3.0.9
 pypika-tortoise==0.1.5
 pytest==7.1.2
+python-dotenv==0.20.0
 pytz==2022.1
 requests==2.28.0
 tomli==2.0.1
+tomlkit==0.11.0
 tortoise-orm==0.19.1
 typing-extensions==4.2.0
 urllib3==1.26.9


### PR DESCRIPTION
This PR:
- Refactors code to write borrowed jokes to the JokesAPI Postgres database instance.
- Refactors the joke fetching logic to get jokes sequentially to avoid redundant jokes 
> Turns out database queries on the [Heroku free tier](https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier) are really slow because now getting and writing ~80 jokes takes a whopping 30-45 seconds compared to ~1 second on my local SQLite database. Oh well! 